### PR TITLE
Add overloaded functions

### DIFF
--- a/src/IToastNotification.cs
+++ b/src/IToastNotification.cs
@@ -8,17 +8,28 @@ namespace NToastNotify
         void AddToastMessage(string title, string message, ToastEnums.ToastType notificationType,
             ToastOption toastOptions);
         
+        void AddSuccessToastMessage(string message);
+        
         void AddSuccessToastMessage(string title, string message);
         
         void AddSuccessToastMessage(string title, string message, ToastOption toastOptions);
+        
+        
+        void AddWarningToastMessage(string message);
         
         void AddWarningToastMessage(string title, string message);
         
         void AddWarningToastMessage(string title, string message, ToastOption toastOptions);
         
+        
+        void AddInfoToastMessage(string message);
+        
         void AddInfoToastMessage(string title, string message);
         
         void AddInfoToastMessage(string title, string message, ToastOption toastOptions);
+        
+        
+        void AddErrorToastMessage(string message);
         
         void AddErrorToastMessage(string title, string message);
         

--- a/src/ToastNotification.cs
+++ b/src/ToastNotification.cs
@@ -57,6 +57,12 @@ namespace NToastNotify
             AddMessages(toastMessage);
         }
 
+        public void AddSuccessToastMessage(string message)
+        {
+            var toastMessage = new ToastMessage(message, "Success", ToastEnums.ToastType.Success);
+            AddMessages(toastMessage);
+        }
+        
         public void AddSuccessToastMessage(string title, string message)
         {
             var toastMessage = new ToastMessage(message, title, ToastEnums.ToastType.Success);
@@ -66,6 +72,12 @@ namespace NToastNotify
         public void AddSuccessToastMessage(string title, string message, ToastOption toastOptions)
         {
             var toastMessage = new ToastMessage(message, title, ToastEnums.ToastType.Success, toastOptions);
+            AddMessages(toastMessage);
+        }
+        
+        public void AddWarningToastMessage(string message)
+        {
+            var toastMessage = new ToastMessage(message, "Warning", ToastEnums.ToastType.Warning);
             AddMessages(toastMessage);
         }
 
@@ -80,6 +92,12 @@ namespace NToastNotify
             var toastMessage = new ToastMessage(message, title, ToastEnums.ToastType.Warning, toastOptions);
             AddMessages(toastMessage);
         }
+        
+        public void AddInfoToastMessage(string message)
+        {
+            var toastMessage = new ToastMessage(message, "Info", ToastEnums.ToastType.Info);
+            AddMessages(toastMessage);
+        }
 
         public void AddInfoToastMessage(string title, string message)
         {
@@ -90,6 +108,12 @@ namespace NToastNotify
         public void AddInfoToastMessage(string title, string message, ToastOption toastOptions)
         {
             var toastMessage = new ToastMessage(message, title, ToastEnums.ToastType.Info, toastOptions);
+            AddMessages(toastMessage);
+        }
+        
+        public void AddErrorToastMessage(string message)
+        {
+            var toastMessage = new ToastMessage(message, "Error", ToastEnums.ToastType.Error);
             AddMessages(toastMessage);
         }
 


### PR DESCRIPTION
This PR adds a new option for the programmers to simplify the toast notification message sending.

This lets them only specify the message they want to send and by default, the Send<State>ToastMessage will use the <State> as the toast title and the type will be set automatically like in the other overloaded functions of Send<State>ToastMessages.