### PR TITLE
Add back the nugetpush.bat script exit code.

### DIFF
--- a/src/nugetpush.bat
+++ b/src/nugetpush.bat
@@ -10,3 +10,4 @@ IF "%1"=="Release" (
     nuget push "%2" %nugetApiKey% -source "nuget.org"    
     )    
 )
+exit 0;


### PR DESCRIPTION
Fix error by adding back the .bat script exit code.