### PR TITLE
Add nonce attribute to inline script element

### DIFF
--- a/src/Components/NToastNotifyViewComponent.cs
+++ b/src/Components/NToastNotifyViewComponent.cs
@@ -18,7 +18,7 @@ namespace NToastNotify
             _nToastNotifyOption = nToastNotifyOption;
         }
 
-        public IViewComponentResult Invoke()
+        public IViewComponentResult Invoke(string? nonce = null)
         {
             var assemblyName = GetType().Assembly.GetName();
             var model = new ToastNotificationViewModel(
@@ -27,7 +27,8 @@ namespace NToastNotify
                 responseHeaderKey: Constants.ResponseHeaderKey,
                 libraryDetails: _library,
                 disableAjaxToasts: _nToastNotifyOption.DisableAjaxToasts,
-                libraryJsPath: $"~/_content/{assemblyName.Name}/{_library.VarName}.js?{assemblyName.Version}");
+                libraryJsPath: $"~/_content/{assemblyName.Name}/{_library.VarName}.js?{assemblyName.Version}",
+                nonce: nonce);
 
             return View("Default", model);
         }

--- a/src/Components/ToastNotificationViewModel.cs
+++ b/src/Components/ToastNotificationViewModel.cs
@@ -2,7 +2,7 @@
 {
     public class ToastNotificationViewModel
     {
-        public ToastNotificationViewModel(string toastMessagesJson, string requestHeaderKey, string responseHeaderKey, ILibrary libraryDetails, bool disableAjaxToasts, string libraryJsPath)
+        public ToastNotificationViewModel(string toastMessagesJson, string requestHeaderKey, string responseHeaderKey, ILibrary libraryDetails, bool disableAjaxToasts, string libraryJsPath, string? nonce)
         {
             ToastMessagesJson = toastMessagesJson;
             RequestHeaderKey = requestHeaderKey;
@@ -10,19 +10,24 @@
             LibraryDetails = libraryDetails;
             DisableAjaxToasts = disableAjaxToasts;
             LibraryJsPath = libraryJsPath;
+            Nonce = nonce;
         }
+
         /// <summary>
         /// JSON string of arrays of message
         /// </summary>
         public string ToastMessagesJson { get; }
+
         /// <summary>
         /// Request header key used to show toast notification in AJAX calls
         /// </summary>
         public string RequestHeaderKey { get; }
+
         /// <summary>
         /// Response header key used to show toast notification in AJAX calls
         /// </summary>
         public string ResponseHeaderKey { get; }
+
         /// <summary>
         /// Library details 
         /// </summary>
@@ -37,5 +42,10 @@
         /// The path of the js
         /// </summary>
         public string LibraryJsPath { get; set; }
+
+        /// <summary>
+        /// Nonce value for allow the inline script to run if CSP is set 
+        /// </summary>
+        public string? Nonce { get; set; }
     }
 }

--- a/src/Views/Shared/Components/NToastNotify/Default.cshtml
+++ b/src/Views/Shared/Components/NToastNotify/Default.cshtml
@@ -5,7 +5,7 @@
         throw new Exception();
 }
 <script src=@Url.Content(@Model.LibraryJsPath) type="text/javascript"></script>
-<script>
+<script nonce=@Model.Nonce>
     if (nToastNotify) {
         nToastNotify.init({
             firstLoadEvent: 'DOMContentLoaded',


### PR DESCRIPTION
The goal of this change is to allow using the toaster messages when a Content-Security-Policy header defined.
This should made possible through using a nonce on the inline script element.
Further explanation [here](https://content-security-policy.com/nonce/)