### PR TITLE
Update runtimecompilation to version 6.0.9 (ensure hot reload continues to work for cshtml)

### DIFF
--- a/src/NToastNotify.csproj
+++ b/src/NToastNotify.csproj
@@ -28,9 +28,9 @@
     <None Include="tsconfig.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.9" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation to 6.0.9

This ensures that dotnet watch hotreload functionality continues to work when editing a .cshtml file. Any version below 6.0.5 breaks this.

Discussion on a similar situation
https://github.com/dotnet/AspNetCore.Docs/issues/23910#issuecomment-1177422108

Discussion on workaround but it's not needed once the version is set to 6.0.9
https://stackoverflow.com/questions/72909569/in-net-6-mvc-view-is-404-not-found-unless-i-manually-change-the-file-type-to#comment130483625_72911491

**Alternatively**
You could just remove RuntimeCompilation since it's not needed anymore in .net 6